### PR TITLE
add option to force inclusion of both legendaries

### DIFF
--- a/classes.php
+++ b/classes.php
@@ -216,6 +216,7 @@ class GeneratorConfig {
     public $include_pok;
     public $include_keleres;
     public $must_include_wormholes_and_legendaries;
+	public $must_include_both_legendaries;
     public $minimum_optimal_influence;
     public $minimum_optimal_resources;
     public $minimum_optimal_total;
@@ -239,6 +240,7 @@ class GeneratorConfig {
         $this->include_pok = get('include_pok') == true;
         $this->include_keleres = get('include_keleres') == true;
         $this->must_include_wormholes_and_legendaries = get('specials') == true;
+		$this->must_include_both_legendaries = get('legendaries') == true;		
         $this->minimum_optimal_influence = (float) get('min_inf');
         $this->minimum_optimal_resources = (float) get('min_res');
         $this->minimum_optimal_total = (float) get('min_total');
@@ -294,6 +296,7 @@ class GeneratorConfig {
             'num_slices' => $this->num_slices,
             'num_factions' => $this->num_factions,
             'must_include_wormholes_and_legendaries' => $this->must_include_wormholes_and_legendaries,
+			'must_include_both_legendaries' => $this->must_include_both_legendaries,
             'max_1_wormhole' => $this->max_1_wormhole,
             'minimum_optimal_influence' => $this->minimum_optimal_influence,
             'minimum_optimal_resources' => $this->minimum_optimal_resources,

--- a/generate.php
+++ b/generate.php
@@ -171,6 +171,9 @@
             $min_beta = round(rand(2, 3));
             $min_legend = round(rand(1, 2));
         }
+		if($config->must_include_both_legendaries) {
+			$min_legend = 2;
+        }
 
         shuffle($tiles['high']);
         shuffle($tiles['mid']);
@@ -188,7 +191,7 @@
         $all = array_merge($selection["high"], $selection["mid"], $selection["low"], $selection["red"]);
 
         // check if the wormhole/legendary count is high enough
-        if($config->must_include_wormholes_and_legendaries) {
+        if($config->must_include_wormholes_and_legendaries || $config->must_include_both_legendaries) {
             // count stuff
             $counts = count_specials($all);
 

--- a/index.php
+++ b/index.php
@@ -139,6 +139,13 @@
                                 <span class="help">Checking this box means that there will be at least 2 or 3 <span class="alpha">alpha</span> wormholes, 2 or 3 <span class="beta">beta</span> wormholes and 1 or 2 legendary planets, divided among the slices.</span>
                             </div>
 
+							<div class="input">
+                                <label for="legendaries" class="check">
+                                    <input type="checkbox" name="legendaries" id="legendaries" /> Map must include both Legendary Planets
+                                </label>
+                                <span class="help">Checking this box means that both Primor and Hope's End will be divided among the slices. (The above option only ensures the inclusion of either.)</span>
+                            </div>
+
                             <div class="input">
                                 <label for="max_wormhole" class="check">
                                     <input type="checkbox" name="max_wormhole" id="max_wormhole" /> Max. 1 wormhole per slice

--- a/js/main.js
+++ b/js/main.js
@@ -85,6 +85,7 @@ function pok_check() {
     let $keleres = $('#keleres');
     let $specials = $('#specials');
     let $max_factions = $('#num_factions');
+	let $legendaries = $('#legendaries');
 
     if($('#pok').is(':checked')) {
         $max_factions.attr("max", 24);
@@ -94,6 +95,9 @@ function pok_check() {
 
         $specials.prop('disabled', false);
         $specials.parent().removeClass('disabled');
+		
+		$legendaries.prop('disabled', false);
+		$legendaries.parent().removeClass('disabled');
     } else {
         $max_factions.attr("max", 17);
 
@@ -105,6 +109,10 @@ function pok_check() {
         $specials.prop('checked', false)
             .prop('disabled', true);
         $specials.parent().addClass('disabled');
+		
+		$legendaries.prop('checked', false)
+		    .prop('disabled', true);
+		$legendaries.parent().addClass('disabled');
     }
 }
 


### PR DESCRIPTION
associated with issue #1 
- adds checkbox for option to select both legendaries
- extends js PoK checks to this checkbox
- extends functionality of counting number of wormholes and legendaries for this option

Disclaimer: only tested with a temporary save/get draft option from a local file instead of the draft saved online as in the live version.