### PR TITLE
fix: declare name property on GeneratorConfig

### DIFF
--- a/classes.php
+++ b/classes.php
@@ -211,6 +211,7 @@ class Slice {
 
 class GeneratorConfig {
     public $players = [];
+    public $name;
     public $num_players;
     public $num_slices;
     public $num_factions;


### PR DESCRIPTION
On PHP 8.2.10
```
appuser@5bfa6b42e92d:/app$ php --version
PHP 8.2.10 (cli) (built: Sep  7 2023 05:57:10) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.2.10, Copyright (c) Zend Technologies
```

getting error re deprecation of dynamic properties, which are used by `GeneratorConfig`
![image](https://github.com/shenanigans-be/miltydraft/assets/51128712/d13e6c87-9db0-4cf4-a93b-1262827f7773)

dynamic properties deprecated in 8.2.0 https://www.php.net/manual/en/language.oop5.properties.php#language.oop5.properties.dynamic-properties

this PR fixes by declaring `name` property on `GeneratorConfig`.

