### PR TITLE
Patch 3 - cap slices at 13, new validation to cap slices at 9 for non-DS+

### DIFF
--- a/classes.php
+++ b/classes.php
@@ -325,10 +325,11 @@ class GeneratorConfig {
         return $config;
     }
 
-    function validate() {
+function validate() {
 
         if(count($this->players) < $this->num_players) return_error('Some players names are not filled out');
         if(!$this->include_pok && $this->num_slices > 5) return_error('Can only draft up to 5 slices without PoK. (And by extension you can only do drafts up to 5 players)');
+        if(!$this->include_ds_tiles && $this->num_slices > 9) return_error('Can only draft up to 9 slices without DS+ Tiles.');
         if($this->num_players < 3) return_error('Please enter more than 3 players');
         if($this->num_factions < $this->num_players) return_error("Can't have less factions than players");
         if($this->num_slices < $this->num_players) return_error("Can't have less slices than players");

--- a/index.php
+++ b/index.php
@@ -101,11 +101,11 @@
                                     <label for="num_slices">
                                         Number of Slices
                                     </label>
-
-                                    <input type="number" id="num_slices" name="num_slices" value="7" max="9" />
+                                    
+                                    <input type="number" id="num_slices" name="num_slices" value="7" max="13" />
                                     <span class="help">
                                         Note: The slices are random and not necessarily balanced (more on that below), so increasing this number makes it more relaxed for players to choose.<br />
-                                        Number of players + 1 is generally recommended. Can't have more than 9 cause you run out of tiles.
+                                        Number of players + 1 is generally recommended. Can't have more than 9 without DS+ tiles or 13 with DS+, cause you run out of tiles.
                                     </span>
                                 </div>
 


### PR DESCRIPTION
allows DS+ games to have the true cap of 13 slices (based on 13 low tier tiles + 26 red tiles, so 13 is the cap even though there's additional high/mid tier tiles unused)