### PR TITLE
Save/Restore draft session and protect draft JSON file secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ composer.lock
 draft_*.json
 .beam
 clean.php
+.idea
+.DS_Store

--- a/claim.php
+++ b/claim.php
@@ -7,13 +7,21 @@ $unclaim = get('unclaim') == 1;
 $playerId = get('player');
 
 if ($unclaim) {
-    $result = $draft->unclaim($playerId)->save();
+    // Not enforcing this here yet because it would break for older drafts
+    // if (!$draft->isPlayerSecret(playerId, get('secret'))) return_error('You are not allowed to do this!');
+    $result = $draft->unclaim($playerId);
 } else {
-    $result = $draft->claim($playerId)->save();
+    $result = $draft->claim($playerId);
 }
 
-return_data([
+$data = [
     'draft' => $draft,
     'player' => $playerId,
     'success' => $result
-]);
+];
+
+if ($unclaim == false) {
+    $data['secret'] = $draft->getPlayerSecret($playerId);
+}
+
+return_data($data);

--- a/data.php
+++ b/data.php
@@ -1,0 +1,12 @@
+<?php
+
+require_once 'boot.php';
+
+$draft = \App\Draft::load(get('draft'));
+
+if ($draft == null) return_error('draft not found');
+
+return_data([
+    'draft' => $draft,
+    'success' => true
+]);

--- a/draft.php
+++ b/draft.php
@@ -56,6 +56,7 @@ $faction_data = json_decode(file_get_contents('data/factions.json'), true);
                         <a href="#map">Map</a>
                         <a href="#log">Log</a>
                         <a href="#config">Config</a>
+                        <a href="#session">Session</a>
                     </div>
                     <div class="right">
                         <a href="#faq">FAQ</a>
@@ -378,6 +379,35 @@ $faction_data = json_decode(file_get_contents('data/factions.json'), true);
                     <button class="undo-last-action">Undo last action</button>
                 </div>
             </div>
+            <div class="tab" id="session">
+                <div class="content-wrap">
+                  <div id="current-session">
+                      <h3>Session</h3>
+                      <p>Make sure to save your passkey so you can restore your session if it is lost (e.g., cleared cache). The passkey is also useful if you want to draft on another device.</p>
+                      <p id="current-session-admin">
+                          <label>Admin Passkey:</label><strong />
+                      </p>
+                      <p id="current-session-player">
+                          <label>Passkey:</label><strong />
+                      </p>
+                      <br>
+                  </div>
+                  <div>
+                      <h3>Restore Session</h3>
+                      <form id="secret-form" action="restore.php" method="post">
+                          <div class="secret_input_section">
+                              <p class="secret_label">Restore a session to be able to draft in this device.</p>
+                              <div class="input secret">
+                                  <input type="text" placeholder="Passkey" name="secret" />
+                              </div>
+                          </div>
+                          <p>
+                              <button type="submit" id="submit">Restore</button>
+                          </p>
+                      </form>
+                  </div>
+                </div>
+            </div>
             <?php require_once 'faq.php'; ?>
         </div>
     </div>
@@ -434,8 +464,9 @@ $faction_data = json_decode(file_get_contents('data/factions.json'), true);
             "pick": "<?= url('pick.php') ?>",
             "regenerate": "<?= url('generate.php') ?>",
             "tile_images": "<?= url('img/tiles') ?>",
-            "data": "<?= get_draft_url($draft->getId(), true) ?>",
-            "undo": "<?= url('undo.php') ?>"
+            "data": "<?= url('data.php') ?>",
+            "undo": "<?= url('undo.php') ?>",
+            "restore": "<?= url('restore.php') ?>"
         }
     </script>
     <script src="<?= url('js/vendor.js?v=' . $_ENV['VERSION']) ?>"></script>

--- a/helpers.php
+++ b/helpers.php
@@ -32,15 +32,6 @@ function url($uri)
     return $_ENV['URL'] . $uri;
 }
 
-function get_draft_url($id, $absolute = false)
-{
-    if ($_ENV['STORAGE'] == 'local') {
-        return (($absolute) ? $_ENV['URL'] : '') . $_ENV['STORAGE_PATH'] . '/draft_' . $id . '.json';
-    } else {
-        return 'https://' . $_ENV['BUCKET'] . '.' . $_ENV['REGION'] . '.digitaloceanspaces.com/draft_' . $id . '.json';
-    }
-}
-
 function return_error($err)
 {
     die(json_encode(['error' => $err]));

--- a/pick.php
+++ b/pick.php
@@ -14,6 +14,9 @@ $is_admin = $draft->isAdminPass(get('admin'));
 if ($draft == null) return_error('draft not found');
 if ($player != $draft->currentPlayer() && !$is_admin) return_error('Not your turn!');
 
+// Not enforcing this here yet because it would break for older drafts
+// if (!$is_admin && !$draft->isPlayerSecret($player, get('secret'))) return_error('You are not allowed to do this!');
+
 if ($index != count($draft->log())) {
     return_error('Draft data out of date, meaning: stuff has been picked or undone while this tab was open.');
 }

--- a/restore.php
+++ b/restore.php
@@ -1,0 +1,23 @@
+<?php
+
+require_once 'boot.php';
+
+$draft = \App\Draft::load(get('draft'));
+$secret = get('secret');
+
+if ($draft->isAdminPass($secret)) {
+  return return_data([
+      'admin' => $secret,
+      'success' => true
+  ]);
+}
+
+$playerId = $draft->getPlayerIdBySecret($secret);
+
+if (!$playerId) return return_error('No session found with that passkey');
+
+return_data([
+    'player' => $playerId,
+    'secret' => $secret,
+    'success' => true
+]);


### PR DESCRIPTION
This PR tries to solve the problem of users losing their sessions.

The main issue is that users don't fully control their browser storage (and the problem gets even worse on mobile devices). Some users even clear everything once in a while. So, it is not enough to rely only on browser storage (localStorage, cookies, IndexDB, etc.). 

Another solution would be to store in the draft JSON the device ID that claimed the seat and always check if the requests came from known users. The problem is that there is no reliable way of getting a unique ID for a device (at least in browsers). This would also have other problems, like making it hard to switch between devices.

So, I took a different approach to this problem: I gave the user the option to backup a session key and restore it later. 

But to allow that, I needed to solve another problem. Today, the app exposes all the draft data to the browser/clients. Any user with a little web development knowledge can read the `admin_pass` value of ANY EXISTING GAME THAT THEY KNOW THE DRAFT ID and enter the game as an admin (I'm not going to expose how that was possible here, but it was really easy). I know that this app doesn't have a lot of bad actors, but I saw the issue and decided to solve it.

So, the first thing to do was to disable serving the whole draft JSON to the client. I've changed the JSON storage to `private`, made the backend serve the JSON, and removed sensitive data before sending to the client.

Now that we have a safe way of storing sensitive data, when the user claims a seat, we can:
* Create a passkey (uniqueId)
* Store it in the draft JSON 
* Send the passkey to the client (only this time)
* Store the passkey locally in the browser (localStorage, just like before)
* Show that passkey for the user (in the new `SESSION` tab)

The next steps allow the user to recover a session if they know a secret/passkey:
* In the same `SESSION` tab, the user asks to restore a session by providing a passkey;
* The backend makes sure the passkey is valid for that draft;
* Then the backend returns the clientId that claimed the seat associated with the passkey;
* The client stores that information and starts behaving like it just claimed the seat

The same was done for the `admin_pass`, allowing admins to restore admin sessions in case they lost them or want to use them to manage the draft on another device.

I've made every effort to ensure that existing drafts are not disrupted. Admins of older drafts will be able to see their passkeys right away. Players of older drafts will need to `UNCLAIM` and then `CLAIM` a seat to see their passkeys.

Full list of changes:
* Added `secrets` field to draft object. Only the server has access to it;
* Removed the `admin_pass` field from the draft object (included in the new `secrets` field);
* Now draft JSON objects are private, requiring the client to go through the backend to fetch the draft data (this is needed to make sure the client never receives secret data);
* Improved claim.php (it was saving twice);
* When someone claims a slot, the backend generates a passkey (in secrets[<playerId>]) and sends it to the client;
* The passkey is visible in the new SESSION tab on the draft screen;
* The admin can also see its passkey in this new screen (admin_pass field);
* Created a method to restore a player session, allowing players and admins to get back control of their draft;

This fixes #44.