### PR TITLE
Legendary ability

### DIFF
--- a/app/Planet.php
+++ b/app/Planet.php
@@ -8,6 +8,7 @@ class Planet
     public $influence;
     public $resources;
     public $legendary;
+    public $legendary_ability;
     public $trait;
     public $specialty;
     public $optimal_total;
@@ -22,6 +23,10 @@ class Planet
         $this->legendary = $json_data['legendary'];
         $this->trait = isset($json_data["trait"]) ? $json_data['trait'] : null;
         $this->specialty = $json_data["specialty"];
+
+        if ($this->legendary) {
+            $this->legendary_ability = $json_data["legendary_ability"];
+        }
 
         // pre-calculate the optimals
         if ($this->influence > $this->resources) {

--- a/app/Planet.php
+++ b/app/Planet.php
@@ -24,9 +24,6 @@ class Planet
         $this->trait = isset($json_data["trait"]) ? $json_data['trait'] : null;
         $this->specialty = $json_data["specialty"];
 
-        if ($this->legendary) {
-            $this->legendary_ability = $json_data["legendary_ability"];
-        }
 
         // pre-calculate the optimals
         if ($this->influence > $this->resources) {

--- a/app/Planet.php
+++ b/app/Planet.php
@@ -8,7 +8,6 @@ class Planet
     public $influence;
     public $resources;
     public $legendary;
-    public $legendary_ability;
     public $trait;
     public $specialty;
     public $optimal_total;
@@ -23,7 +22,6 @@ class Planet
         $this->legendary = $json_data['legendary'];
         $this->trait = isset($json_data["trait"]) ? $json_data['trait'] : null;
         $this->specialty = $json_data["specialty"];
-
 
         // pre-calculate the optimals
         if ($this->influence > $this->resources) {

--- a/app/Slice.php
+++ b/app/Slice.php
@@ -13,6 +13,7 @@ class Slice
     public $total_optimal = 0;
     public $wormholes = [];
     public $specialties = [];
+    public $legendaries = [];
 
     /**
      * Slice constructor.
@@ -35,6 +36,9 @@ class Slice
                 if ($planet->specialty != null) {
                     $this->specialties[] = $planet->specialty;
                 }
+                if ($planet->legendary) {
+                    $this->legendaries[] = $planet->legendary_ability;
+                }
             }
         }
 
@@ -48,6 +52,7 @@ class Slice
             'specialties' => $this->specialties,
             'wormholes' => $this->wormholes,
             'has_legendaries' => Tile::countSpecials($this->tiles)['legendary'] > 0,
+            'legendaries' => $this->legendaries,
             'total_influence' => $this->total_influcence,
             'total_resources' => $this->total_resources,
             'optimal_influence' => $this->optimal_influence,

--- a/app/Slice.php
+++ b/app/Slice.php
@@ -37,7 +37,7 @@ class Slice
                     $this->specialties[] = $planet->specialty;
                 }
                 if ($planet->legendary) {
-                    $this->legendaries[] = $planet->legendary_ability;
+                    $this->legendaries[] = $planet->legendary;
                 }
             }
         }

--- a/data/tiles.json
+++ b/data/tiles.json
@@ -935,8 +935,7 @@
             "influence": 1,
             "trait": "cultural",
             "specialty": null,
-            "legendary": true,
-            "legendary_ability": "You may exhaust this card at the end of your turn to place up to 2 infantry from your reinforcements on any planet you control"
+            "legendary": "You may exhaust this card at the end of your turn to place up to 2 infantry from your reinforcements on any planet you control"
         }]
     },
     "66": {
@@ -948,8 +947,7 @@
             "influence": 0,
             "trait": "hazardous",
             "specialty": null,
-            "legendary": true,
-            "legendary_ability": "You may exhaust this card at the end of your turn to place 1 mech from your reinforcements on any planet you control, or draw 1 action card"
+            "legendary": "You may exhaust this card at the end of your turn to place 1 mech from your reinforcements on any planet you control, or draw 1 action card"
         }]
     },
     "67": {

--- a/data/tiles.json
+++ b/data/tiles.json
@@ -935,7 +935,8 @@
             "influence": 1,
             "trait": "cultural",
             "specialty": null,
-            "legendary": true
+            "legendary": true,
+            "legendary_ability": "You may exhaust this card at the end of your turn to place up to 2 infantry from your reinforcements on any planet you control"
         }]
     },
     "66": {
@@ -947,7 +948,8 @@
             "influence": 0,
             "trait": "hazardous",
             "specialty": null,
-            "legendary": true
+            "legendary": true,
+            "legendary_ability": "You may exhaust this card at the end of your turn to place 1 mech from your reinforcements on any planet you control, or draw 1 action card"
         }]
     },
     "67": {

--- a/data/tiles.json
+++ b/data/tiles.json
@@ -1199,7 +1199,7 @@
             "influence": 3,
             "trait": "cultural",
             "specialty": null,
-            "legendary": true
+            "legendary": "You may exhaust this card at the end of your turn to gain 2 trade goods or convert all of your commodities into trade goods"
         }]
     },
     "83A": {
@@ -2075,7 +2075,7 @@
                 "influence": 2,
                 "trait": "industrial",
                 "specialty": null,
-                "legendary": true
+                "legendary": "You may exhaust this card at the end of your turn to place 1 cruiser from your reinforcements in any system that contains 1 or more of your ships."
                 }]
         },
 
@@ -2088,7 +2088,7 @@
                 "influence": 2,
                 "trait": "hazardous",
                 "specialty": null,
-                "legendary": true
+                "legendary": "You may exhaust this card at the end of your turn to place 1 frontier token in a system that does not contain a planet."
                 }]
         },
 
@@ -2101,7 +2101,7 @@
                 "influence": 0,
                 "trait": "industrial",
                 "specialty": null,
-                "legendary": true
+                "legendary": "After an agenda is revealed, you may exhaust this card to predict aloud an outcome of that agenda. If your prediction is correct, draw 1 secret objective."
                 }]
         },
 
@@ -2114,7 +2114,7 @@
                 "influence": 3,
                 "trait": "industrial",
                 "specialty": null,
-                "legendary": true
+                "legendary": "ACTION: Exhaust this card to replace 1 of your non-faction non-unit upgrade technologies with another technology from your technology deck with the same number of prerequisites."
                 }]
         },
 
@@ -2364,7 +2364,7 @@
                 "influence": 1,
                 "trait": "hazardous",
                 "specialty": null,
-                "legendary": true,
+                "legendary": "You may exhaust this card at the end of your turn to remove 1 of your ships from the game board and place that unit in an adjacent system that does not contain another player’s ships.",
                 "anomaly": "nebula"
                 }]
 

--- a/draft.php
+++ b/draft.php
@@ -140,13 +140,13 @@ $faction_data = json_decode(file_get_contents('data/factions.json'), true);
 
                                             <div class="info">
                                                 <?php foreach ($slice['specialties'] as $s) : ?>
-                                                    <img class="tech-specialty" src="<?= url('img/tech/' . $s . '.webp') ?>" alt="<?= $s ?>" />
+                                                    <img class="tech-specialty" title="<?= $s ?>" src="<?= url('img/tech/' . $s . '.webp') ?>" alt="<?= $s ?>" />
                                                 <?php endforeach; ?>
 
 
-                                                <?php if (isset($slice['has_legendaries']) && $slice['has_legendaries']) : ?>
-                                                    <abbr class="legendary" title="Contains legendary planet"><img src="<?= url('img/legendary.webp') ?>"></abbr>
-                                                <?php endif; ?>
+                                                <?php foreach ($slice['legendaries'] as $l) : ?>
+                                                    <abbr class="legendary" title="<?= $l ?>"><img src="<?= url('img/legendary.webp') ?>"></abbr>
+                                                <?php endforeach; ?>
 
                                                 <?php foreach ($slice['wormholes'] as $w) : ?>
                                                     <?php if ($w == 'alpha') : ?>


### PR DESCRIPTION
During the draft phase, now the legendary planet ability shows when hovering on the icon.
![image](https://github.com/user-attachments/assets/4b864f35-72f5-485c-b274-dbe0a4efa286)

To implement this, I:
1. Changed the legendary value in the json from true to the ability text
2. Added a field to Slice.php to hold the text in a similar way as the specialties are stored.
3. Changed draft.php to show legendaries the same way specialties are

I also added a title to the specialties.
![image](https://github.com/user-attachments/assets/ca991a50-880c-4280-a6c4-2789a6aa352f)

fixes #47 
