### PR TITLE
admin can unclaim for anyone and then they can reclaim

### DIFF
--- a/js/draft.js
+++ b/js/draft.js
@@ -241,9 +241,12 @@ function who_am_i() {
 
     window.IS_ADMIN = (admin_id == draft.admin_pass);
 
-    if (IS_ADMIN) $('#admin-msg').show();
-
-    $('.unclaim').hide();
+    if (IS_ADMIN) {
+        $('#admin-msg').show();
+        $('.unclaim').show();
+    } else {
+        $('.unclaim').hide();
+    }
 
     // Check for faulty local storage
     if (player_id && draft.draft.players[player_id].claimed == false) {


### PR DESCRIPTION
If Adriano's PR is accepted, this might not be necessary. I have made the unclaim button show up for each person on the admin page.
![image](https://github.com/user-attachments/assets/422ab1e1-033f-44d7-bef7-ef5ebfd995b8)

The claim buttons still disappears appropriately for admins and non-admins and the unclaim button works for both as well.
![image](https://github.com/user-attachments/assets/ea558eab-0ae1-4e8e-8ae5-bd6093dc2c39)
