### PR TITLE
Allow admin to unclaim any seat

### DIFF
--- a/claim.php
+++ b/claim.php
@@ -7,8 +7,7 @@ $unclaim = get('unclaim') == 1;
 $playerId = get('player');
 
 if ($unclaim) {
-    // Not enforcing this here yet because it would break for older drafts
-    // if (!$draft->isPlayerSecret(playerId, get('secret'))) return_error('You are not allowed to do this!');
+    if (!$draft->isPlayerSecret($playerId, get('secret')) && !$draft->isAdminPass(get('admin'))) return_error('You are not allowed to do this!');
     $result = $draft->unclaim($playerId);
 } else {
     $result = $draft->claim($playerId);

--- a/js/draft.js
+++ b/js/draft.js
@@ -234,8 +234,9 @@ $(document).ready(function () {
                 dataType: 'json',
                 data: {
                     'draft': draft.id,
-                    'player': localStorage.getItem('draft_' + draft.id),
+                    'player': $(this).data('id'),
                     'secret': localStorage.getItem('secret_' + draft.id),
+                    'admin': localStorage.getItem('admin_' + draft.id),
                     'unclaim': 1
                 },
                 success: function (resp) {
@@ -298,6 +299,15 @@ function who_am_i() {
             window.me = p;
             $('.you[data-id="' + me.id + '"]').show();
             $('.unclaim[data-id="' + me.id + '"]').show();
+        }
+    }
+
+    if (IS_ADMIN) {
+        for (p_id in draft.draft.players) {
+            let p = draft.draft.players[p_id];
+            if (p.claimed) {
+                $('.unclaim[data-id="' + p_id + '"]').show();
+            }
         }
     }
 }

--- a/pick.php
+++ b/pick.php
@@ -14,8 +14,8 @@ $is_admin = $draft->isAdminPass(get('admin'));
 if ($draft == null) return_error('draft not found');
 if ($player != $draft->currentPlayer() && !$is_admin) return_error('Not your turn!');
 
-// Not enforcing this here yet because it would break for older drafts
-// if (!$is_admin && !$draft->isPlayerSecret($player, get('secret'))) return_error('You are not allowed to do this!');
+Not enforcing this here yet because it would break for older drafts
+if (!$is_admin && !$draft->isPlayerSecret($player, get('secret'))) return_error('You are not allowed to do this!');
 
 if ($index != count($draft->log())) {
     return_error('Draft data out of date, meaning: stuff has been picked or undone while this tab was open.');


### PR DESCRIPTION
Inspired by @MikeMcFall PR, this PR allows the admin to unclaim any occupied seat.

Only seats claimed can be unclaimed. So this also has the benefit of showing the admin which seats are already claimed.

This PR also enforces that only the current player or the admin can claim/unclaim seats or draft. This check has been disabled since my last PR, so it did not break existing or older drafts. But it should be enabled again since more than one month has passed.