### PR TITLE
Add explicit seed support for reproducible draft generation

### DIFF
--- a/app/Draft.php
+++ b/app/Draft.php
@@ -7,6 +7,8 @@ use Aws\S3\Exception\S3Exception;
 
 class Draft implements \JsonSerializable
 {
+    private const SEED_OFFSET_PLAYER_ORDER = 2;
+
     private static self $instance;
     private bool $done;
 
@@ -238,6 +240,11 @@ class Draft implements \JsonSerializable
 
     public function regenerate(bool $regen_slices, bool $regen_factions, bool $regen_order): void
     {
+        if ($this->config->seed !== null) {
+            mt_srand($this->config->seed);
+            $this->config->seed = mt_rand(1, GeneratorConfig::MAX_SEED_VALUE);
+        }
+
         if ($regen_factions) {
             $this->factions = Generator::factions($this->config);
         }
@@ -258,6 +265,10 @@ class Draft implements \JsonSerializable
         $player_data = [];
 
         $alliance_mode =  $this->config->alliance != null;
+
+        if ($this->config->seed !== null) {
+            mt_srand($this->config->seed + self::SEED_OFFSET_PLAYER_ORDER);
+        }
 
         if ($alliance_mode) {
             $playerTeams = $this->generateTeams();

--- a/app/Generator.php
+++ b/app/Generator.php
@@ -4,10 +4,17 @@ namespace App;
 
 class Generator
 {
+    private const SEED_OFFSET_SLICES = 0;
+    private const SEED_OFFSET_FACTIONS = 1;
+
     public static function slices($config, $previous_tries = 0)
     {
         if ($previous_tries > 100) {
             return_error("Selection contains no valid slices. This happens occasionally to valid configurations but it probably means that the parameters are impossible.");
+        }
+
+        if ($config->seed !== null) {
+            mt_srand($config->seed + self::SEED_OFFSET_SLICES + $previous_tries);
         }
 
         // Gather Tiles
@@ -67,6 +74,10 @@ class Generator
             return false;
         }
 
+        if ($config->seed !== null && $previous_tries > 0) {
+            mt_srand($config->seed + self::SEED_OFFSET_SLICES + $previous_tries);
+        }
+
         // reshuffle
         shuffle($tiles["high"]);
         shuffle($tiles["mid"]);
@@ -115,6 +126,10 @@ class Generator
 
         if ($previous_tries > 2000) {
             return_error("Max. number of tries exceeded: no valid tile selection found");
+        }
+
+        if ($config->seed !== null && $previous_tries > 0) {
+            mt_srand($config->seed + self::SEED_OFFSET_SLICES + $previous_tries);
         }
 
         shuffle($tiles['high']);
@@ -197,6 +212,10 @@ class Generator
      */
     public static function factions($config)
     {
+
+        if ($config->seed !== null) {
+            mt_srand($config->seed + self::SEED_OFFSET_FACTIONS);
+        }
 
         $possible_factions = self::filtered_factions($config);
 

--- a/templates/draft.php
+++ b/templates/draft.php
@@ -307,6 +307,9 @@ $faction_data = json_decode(file_get_contents('data/factions.json'), true);
                         </strong>
                     </p>
                     <p>
+                        <label>Seed:</label> <strong><?= $config->seed ?></strong>
+                    </p>
+                    <p>
                         <label>Slices Generated:</label>
                         <strong>
                             <?php foreach ($draft->slices() as $slice_id => $slice) : ?>

--- a/templates/generate.php
+++ b/templates/generate.php
@@ -367,6 +367,18 @@
                                     </span>
                             </div>
 
+                            <h4>Seed</h4>
+                            <div class="input">
+                                <label for="seed">
+                                    Random Seed (optional)
+                                </label>
+
+                                <input type="number" id="seed" name="seed" placeholder="Leave empty for random" />
+                                <span class="help">
+                                    Set an explicit seed for reproducible draft generation. If left empty, a random seed will be automatically generated. The seed will be displayed after generation, allowing any draft to be reproduced exactly.
+                                </span>
+                            </div>
+
                             <h4>Custom Factions</h4>
                             <div class="input">
                                 <label>


### PR DESCRIPTION
Implements: https://github.com/shenanigans-be/miltydraft/issues/59

This adds optional seed functionality under advanced options to ensure all drafts are fully reproducible. Allows organizers to announce "We'll use Friday's lottery numbers as seed" ensuring that no one can manipulate the draft while at the same time keeping it unpredictable. 

**Advanced settings**
<img width="773" height="383" alt="Screenshot 2025-10-07 at 19 27 09" src="https://github.com/user-attachments/assets/e7dca873-dc76-4d65-a8f3-26cca4855810" />


**Config**
<img width="868" height="319" alt="Screenshot 2025-10-07 at 19 27 25" src="https://github.com/user-attachments/assets/f3eb1742-642b-4d17-838f-5c59c7dc4a1e" />
